### PR TITLE
Add LangChain example

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,17 @@ test
 
 ## Examples
 
-To try a simple LangChain script, install dependencies:
+To try a simple LangChain script, install dependencies from `requirements.txt`:
 
 ```
-pip install langchain openai
+pip install -r requirements.txt
 ```
 
-Then run the sample:
+Then run the sample with your question (defaults to a Korean prompt if omitted):
 
 ```
-python examples/langchain_sample.py
+python examples/langchain_sample.py "What is LangChain?"
 ```
 
-Make sure the `OPENAI_API_KEY` environment variable is set before running.
+Make sure the `OPENAI_API_KEY` environment variable is set before running. If it
+is missing, the script will exit with a clear error message.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # test
+
 test
+
+## Examples
+
+To try a simple LangChain script, install dependencies:
+
+```
+pip install langchain openai
+```
+
+Then run the sample:
+
+```
+python examples/langchain_sample.py
+```
+
+Make sure the `OPENAI_API_KEY` environment variable is set before running.

--- a/examples/langchain_sample.py
+++ b/examples/langchain_sample.py
@@ -1,17 +1,37 @@
-# LangChain minimal example
+"""Simple LangChain sample that asks a question via OpenAI."""
+
+import argparse
+import os
+
 from langchain_openai import ChatOpenAI
 from langchain.prompts import ChatPromptTemplate
 
-# You must set the OPENAI_API_KEY environment variable before running this.
 
-def main():
+def main() -> None:
+    """Run a single question through the chat model."""
+    if not os.environ.get("OPENAI_API_KEY"):
+        raise SystemExit(
+            "OPENAI_API_KEY environment variable is not set."
+        )
+
+    parser = argparse.ArgumentParser(description="Minimal LangChain example")
+    parser.add_argument(
+        "question",
+        nargs="?",
+        default="LangChain 시작을 도와줘",
+        help="Question to ask the model",
+    )
+    args = parser.parse_args()
+
     llm = ChatOpenAI()
-    prompt = ChatPromptTemplate.from_messages([
-        ("system", "You are a helpful assistant."),
-        ("human", "{question}")
-    ])
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            ("system", "You are a helpful assistant."),
+            ("human", "{question}"),
+        ]
+    )
     chain = prompt | llm
-    result = chain.invoke({"question": "LangChain 시작을 도와줘"})
+    result = chain.invoke({"question": args.question})
     print(result.content)
 
 if __name__ == "__main__":

--- a/examples/langchain_sample.py
+++ b/examples/langchain_sample.py
@@ -1,0 +1,18 @@
+# LangChain minimal example
+from langchain_openai import ChatOpenAI
+from langchain.prompts import ChatPromptTemplate
+
+# You must set the OPENAI_API_KEY environment variable before running this.
+
+def main():
+    llm = ChatOpenAI()
+    prompt = ChatPromptTemplate.from_messages([
+        ("system", "You are a helpful assistant."),
+        ("human", "{question}")
+    ])
+    chain = prompt | llm
+    result = chain.invoke({"question": "LangChain 시작을 도와줘"})
+    print(result.content)
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+langchain-openai
+langchain
+openai

--- a/tests/test_langchain_sample.py
+++ b/tests/test_langchain_sample.py
@@ -1,0 +1,57 @@
+import builtins
+from types import SimpleNamespace
+import sys
+import importlib
+import types
+import pytest
+
+
+def load_sample(monkeypatch):
+    """Import sample module with stubbed dependencies."""
+    stub_openai = types.ModuleType("langchain_openai")
+    class DummyLLM:
+        def __init__(self, *args, **kwargs):
+            pass
+        def __ror__(self, other):
+            return self
+        def invoke(self, params):
+            return SimpleNamespace(content=f"echo: {params['question']}")
+    stub_openai.ChatOpenAI = DummyLLM
+    monkeypatch.setitem(sys.modules, "langchain_openai", stub_openai)
+
+    stub_langchain = types.ModuleType("langchain")
+    prompts = types.ModuleType("prompts")
+    class DummyPrompt:
+        def __init__(self, msgs):
+            self.msgs = msgs
+        def __or__(self, other):
+            return other
+        @classmethod
+        def from_messages(cls, msgs):
+            return cls(msgs)
+    prompts.ChatPromptTemplate = DummyPrompt
+    stub_langchain.prompts = prompts
+    monkeypatch.setitem(sys.modules, "langchain", stub_langchain)
+    monkeypatch.setitem(sys.modules, "langchain.prompts", prompts)
+
+    return importlib.import_module("examples.langchain_sample")
+
+
+def test_missing_api_key(monkeypatch):
+    sample = load_sample(monkeypatch)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with pytest.raises(SystemExit) as excinfo:
+        sample.main()
+    assert "OPENAI_API_KEY" in str(excinfo.value)
+
+
+def test_custom_question(monkeypatch):
+    sample = load_sample(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    # capture output
+    monkeypatch.setattr(builtins, "print", lambda msg: setattr(test_custom_question, "output", msg))
+    monkeypatch.setattr(sys, "argv", ["langchain_sample.py", "hello"])
+
+    sample.main()
+    assert getattr(test_custom_question, "output", "") == "echo: hello"


### PR DESCRIPTION
## Summary
- add a simple LangChain script that uses `ChatOpenAI`
- document how to run the example in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846907230ac832382685a4bbf97cfea